### PR TITLE
Average distance and variogram at lag=0

### DIFF
--- a/src/empirical.jl
+++ b/src/empirical.jl
@@ -124,7 +124,7 @@ distance(γ::EmpiricalVariogram) = γ.distance
     merge(γα, γβ)
 
 Merge the empirical variogram `γα` with the empirical variogram `γβ`
-assuming that both variograms have the same abscissa.
+assuming that both variograms have the same number of lags.
 """
 function merge(γα::EmpiricalVariogram{D}, γβ::EmpiricalVariogram{D}) where {D}
   xα = γα.abscissa

--- a/src/empirical.jl
+++ b/src/empirical.jl
@@ -127,13 +127,15 @@ Merge the empirical variogram `γα` with the empirical variogram `γβ`
 assuming that both variograms have the same abscissa.
 """
 function merge(γα::EmpiricalVariogram{D}, γβ::EmpiricalVariogram{D}) where {D}
+  xα = γα.abscissa
+  xβ = γβ.abscissa
   yα = γα.ordinate
   yβ = γβ.ordinate
   nα = γα.counts
   nβ = γβ.counts
 
   n = nα + nβ
-  x = γα.abscissa
+  x = @. (xα*nα + xβ*nβ) / n
   y = @. (yα*nα + yβ*nβ) / n
   y[n .== 0] .= 0
 
@@ -215,7 +217,7 @@ function ball_search_accum(sdata, var₁, var₂, hmax, nlags, distance)
 
   # lag sums and counts
   xsums = zeros(nlags)
-  ysums   = zeros(nlags)
+  ysums = zeros(nlags)
   counts = zeros(Int, nlags)
 
   # preallocate memory for coordinates

--- a/src/empirical.jl
+++ b/src/empirical.jl
@@ -95,6 +95,7 @@ function EmpiricalVariogram(sdata, var₁::Symbol, var₂::Symbol=var₁;
 
   # variogram abscissa
   abscissa = @. (cumdists / counts)
+  abscissa[counts .== 0] .= range(δh/2, stop=hmax - δh/2, length=nlags)[counts .== 0]
 
   # variogram ordinate
   ordinate = @. (sums / counts) / 2
@@ -191,12 +192,13 @@ function full_search_accum(sdata, var₁, var₂, hmax, nlags, distance)
 
       # bin (or lag) where to accumulate result
       lag = ceil(Int, h / δh)
-      @assert h > 0 "duplicated coordinates for variography"
 
-      if lag ≤ nlags && !ismissing(v) && !isnan(v)# && lag != 0
+      if lag ≤ nlags && !ismissing(v) && lag != 0
         sums[lag] += v
         cumdists[lag] += h
         counts[lag] += 1
+      elseif lag == 0
+        @warn "pairs with duplicated coordinates are being ignored for variography"
       end
     end
   end
@@ -242,12 +244,13 @@ function ball_search_accum(sdata, var₁, var₂, hmax, nlags, distance)
 
       # bin (or lag) where to accumulate result
       lag = ceil(Int, h / δh)
-      @assert h > 0 "duplicated coordinates for variography"
 
-      if lag ≤ nlags && !ismissing(v) && !isnan(v)# && lag != 0
+      if lag ≤ nlags && !ismissing(v) && lag != 0
         sums[lag] += v
         cumdists[lag] += h
         counts[lag] += 1
+      elseif lag == 0
+        @warn "pairs with duplicated coordinates are being ignored for variography"
       end
     end
   end

--- a/test/empirical.jl
+++ b/test/empirical.jl
@@ -3,7 +3,7 @@
   sdata = georef((z=ones(3),), Matrix(1.0I, 3, 3))
   γ = EmpiricalVariogram(sdata, :z, nlags=2, maxlag=2.)
   x, y, n = values(γ)
-  @test x ≈ [1/2, 3/2]
+  @test x ≈ [1/2, √2]
   @test y[2] == 0.
   @test n == [0, 3]
 
@@ -19,7 +19,7 @@
   sdata = georef((z=ones(3),), Matrix(1I, 3, 3))
   γ = EmpiricalVariogram(sdata, :z, nlags=2, maxlag=2, algo=:full)
   x, y, n = values(γ)
-  @test x ≈ [1/2, 3/2]
+  @test x ≈ [1/2, √2]
   @test y[2] == 0.
   @test n == [0, 3]
 
@@ -48,7 +48,7 @@
   d = georef((z=rand(100,100),))
   γ = EmpiricalVariogram(d, :z)
   @test sprint(show, γ) == "EmpiricalVariogram"
-  @test sprint(show, MIME"text/plain"(), γ) == "EmpiricalVariogram\n  abscissa: (0.35001785668734103, 13.650696410806301)\n  ordinate: (0.0, 0.083920131066808)\n  N° pairs: 2706158\n"
+  @test sprint(show, MIME"text/plain"(), γ) == "EmpiricalVariogram\n  abscissa: (0.35001785668734103, 13.631423424599443)\n  ordinate: (0.0, 0.083920131066808)\n  N° pairs: 2706158\n"
 
   if visualtests
     wl = geostatsimage("WalkerLake")


### PR DESCRIPTION
Hi @juliohm 
Check out if you're comfortable with this solution
For lag==0, I tested two scenarios: with an assertion error and with a warning (the second one is in this pull request). None of them decreased the speed performance. I chose the warning solution because it's less radical, just ignoring the duplicate pairs and doesn't crash.
For average distance, I used the previous fixed lags if counts == 0, in case it affects plots or something else