### PR TITLE
Adding support for NuggetEffect variogram

### DIFF
--- a/src/Variography.jl
+++ b/src/Variography.jl
@@ -43,6 +43,7 @@ export
 
   # theoretical variograms
   Variogram,
+  NuggetEffect,
   GaussianVariogram,
   ExponentialVariogram,
   MaternVariogram,

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -46,7 +46,8 @@ return the one with minimum error as defined by the algorithm `algo`.
 function fit(::Type{Variogram}, γ::EmpiricalVariogram,
              algo::VariogramFitAlgo=WeightedLeastSquares())
   # fit each variogram type
-  res = [fit_impl(V, γ, algo) for V in STATIONARY]
+  varsubset = filter(x -> x != NuggetEffect, STATIONARY) # excluding NuggetEffect until is properly managed
+  res = [fit_impl(V, γ, algo) for V in varsubset]
   γs, es = first.(res), last.(res)
 
   # return best candidate

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -46,8 +46,7 @@ return the one with minimum error as defined by the algorithm `algo`.
 function fit(::Type{Variogram}, γ::EmpiricalVariogram,
              algo::VariogramFitAlgo=WeightedLeastSquares())
   # fit each variogram type
-  varsubset = filter(x -> x != NuggetEffect, STATIONARY) # excluding NuggetEffect until is properly managed
-  res = [fit_impl(V, γ, algo) for V in varsubset]
+  res = [fit_impl(V, γ, algo) for V in STATIONARY if V != NuggetEffect] # excluding NuggetEffect until is properly managed
   γs, es = first.(res), last.(res)
 
   # return best candidate

--- a/src/theoretical.jl
+++ b/src/theoretical.jl
@@ -73,13 +73,11 @@ A pure nugget effect (random) variogram with nugget `n`
   nugget::T = 0.0
   distance::D = Euclidean()
 end
-
+NuggetEffect(n) = NuggetEffect(nugget=n)
 (γ::NuggetEffect)(h) = (h > 0) * γ.nugget
 Base.range(::NuggetEffect{T,D}) where {T,D} = zero(T)
 sill(γ::NuggetEffect) = γ.nugget
 isstationary(::Type{<:NuggetEffect}) = true
-
-NuggetEffect(n) = NuggetEffect(nugget=n)
 
 """
     GaussianVariogram(sill=s, range=r, nugget=n, distance=d)

--- a/src/theoretical.jl
+++ b/src/theoretical.jl
@@ -71,19 +71,13 @@ A pure nugget effect (random) variogram with nugget `n`
 """
 @with_kw struct NuggetEffect{T,D} <: Variogram{T,D}
   nugget::T = 0.0
-  sill::T = 0.0
-  range::T = 0.0
   distance::D = Euclidean()
 end
-function NuggetEffect(n::T) where {T <: AbstractFloat}
-  @assert n > 0 "Nugget effect should be greater than zero"
-  NuggetEffect(nugget=n)
-end
 
-(γ::NuggetEffect{T,D})(h) where {T,D} = (h > 0) ? γ.nugget : zero(T)
+(γ::NuggetEffect)(h) = (h > 0) * γ.nugget
 Base.range(::NuggetEffect{T,D}) where {T,D} = zero(T)
-sill(γ::NuggetEffect) = nugget(γ)
-isstationary(::Type{<:NuggetEffect}) = true
+sill(γ::NuggetEffect) = γ.nugget
+isstationary(::Type{<:NuggetEffect}) = false
 
 """
     GaussianVariogram(sill=s, range=r, nugget=n, distance=d)

--- a/src/theoretical.jl
+++ b/src/theoretical.jl
@@ -77,7 +77,9 @@ end
 (γ::NuggetEffect)(h) = (h > 0) * γ.nugget
 Base.range(::NuggetEffect{T,D}) where {T,D} = zero(T)
 sill(γ::NuggetEffect) = γ.nugget
-isstationary(::Type{<:NuggetEffect}) = false
+isstationary(::Type{<:NuggetEffect}) = true
+
+NuggetEffect(n) = NuggetEffect(nugget=n)
 
 """
     GaussianVariogram(sill=s, range=r, nugget=n, distance=d)

--- a/src/theoretical.jl
+++ b/src/theoretical.jl
@@ -65,6 +65,27 @@ Evaluate the variogram at points `x` and `y`.
 # IMPLEMENTATIONS
 #------------------
 """
+    NuggetEfect(n)
+
+A pure nugget effect (random) variogram with nugget `n`
+"""
+@with_kw struct NuggetEffect{T,D} <: Variogram{T,D}
+  nugget::T = 0.0
+  sill::T = 0.0
+  range::T = 0.0
+  distance::D = Euclidean()
+end
+function NuggetEffect(n::T) where {T <: AbstractFloat}
+  @assert n > 0 "Nugget effect should be greater than zero"
+  NuggetEffect(nugget=n)
+end
+
+(γ::NuggetEffect{T,D})(h) where {T,D} = (h > 0) ? γ.nugget : zero(T)
+Base.range(::NuggetEffect{T,D}) where {T,D} = zero(T)
+sill(γ::NuggetEffect) = nugget(γ)
+isstationary(::Type{<:NuggetEffect}) = true
+
+"""
     GaussianVariogram(sill=s, range=r, nugget=n, distance=d)
 
 A Gaussian variogram with sill `s`, range `r` and nugget `n`.

--- a/test/theoretical.jl
+++ b/test/theoretical.jl
@@ -4,7 +4,7 @@
   x, y = rand(3), rand(3)
 
   # stationary variogram models
-  γs = [GaussianVariogram(), ExponentialVariogram(),
+  γs = [NuggetEffect(), GaussianVariogram(), ExponentialVariogram(),
         MaternVariogram(), SphericalVariogram(),
         SphericalVariogram(range=2.), CubicVariogram(),
         PentasphericalVariogram(), SineHoleVariogram()]
@@ -36,6 +36,24 @@
   for γ in (γs ∪ γn ∪ γnd)
     @test !isnan(γ(0.)) && !isinf(γ(0.))
   end
+
+  # nugget effect
+  γ = NuggetEffect(0.2)
+  @test nugget(γ) == 0.2
+  @test sill(γ) == 0.2
+  @test range(γ) == 0.0
+
+  # Sum and Scaled Variogram
+  γ₁ = γ + GaussianVariogram(nugget=0.1, sill=0.8, range=50.0)
+  @test nugget(γ₁) ≈ 0.3
+  @test sill(γ₁) ≈ 1.0
+  @test range(γ₁) ≈ 50.0
+  γ₁ = 2.0*γ
+  @test nugget(γ₁) ≈ 0.4
+  @test sill(γ₁) ≈ 0.4
+  @test range(γ₁) ≈ 0.0
+
+
 
   # sill is defined for compositive stationary models
   γ = GaussianVariogram(sill=1.) + ExponentialVariogram(sill=2.)

--- a/test/theoretical.jl
+++ b/test/theoretical.jl
@@ -4,7 +4,7 @@
   x, y = rand(3), rand(3)
 
   # stationary variogram models
-  γs = [GaussianVariogram(), ExponentialVariogram(),
+  γs = [NuggetEffect(), GaussianVariogram(), ExponentialVariogram(),
         MaternVariogram(), SphericalVariogram(),
         SphericalVariogram(range=2.), CubicVariogram(),
         PentasphericalVariogram(), SineHoleVariogram()]
@@ -43,17 +43,15 @@
   @test sill(γ) == 0.2
   @test range(γ) == 0.0
 
-  # Sum and Scaled Variogram
-  γ₁ = γ + GaussianVariogram(nugget=0.1, sill=0.8, range=50.0)
+  # Sum and Scaled Variogram for NuggetEffect
+  γ₁ = NuggetEffect(0.2) + GaussianVariogram(nugget=0.1, sill=0.8, range=50.0)
   @test nugget(γ₁) ≈ 0.3
   @test sill(γ₁) ≈ 1.0
   @test range(γ₁) ≈ 50.0
-  γ₁ = 2.0*γ
+  γ₁ = 2.0*NuggetEffect(0.2)
   @test nugget(γ₁) ≈ 0.4
   @test sill(γ₁) ≈ 0.4
   @test range(γ₁) ≈ 0.0
-
-
 
   # sill is defined for compositive stationary models
   γ = GaussianVariogram(sill=1.) + ExponentialVariogram(sill=2.)

--- a/test/theoretical.jl
+++ b/test/theoretical.jl
@@ -4,7 +4,7 @@
   x, y = rand(3), rand(3)
 
   # stationary variogram models
-  γs = [NuggetEffect(), GaussianVariogram(), ExponentialVariogram(),
+  γs = [GaussianVariogram(), ExponentialVariogram(),
         MaternVariogram(), SphericalVariogram(),
         SphericalVariogram(range=2.), CubicVariogram(),
         PentasphericalVariogram(), SineHoleVariogram()]
@@ -38,7 +38,7 @@
   end
 
   # nugget effect
-  γ = NuggetEffect(0.2)
+  γ = NuggetEffect(nugget=0.2)
   @test nugget(γ) == 0.2
   @test sill(γ) == 0.2
   @test range(γ) == 0.0


### PR DESCRIPTION
This PR adds `NuggetEffect` as a new variogram structure.
It includes sill and range attributes just for variogram fitting to work (they are not used at all). This can be revisited.