### PR TITLE
fix typo

### DIFF
--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -28,7 +28,7 @@ WeightedLeastSquares() = WeightedLeastSquares(nothing)
 
 """
     fit(V, γ, [algo])
-    fit(V, γ, [weigthfun])
+    fit(V, γ, [weightfun])
 
 Fit theoretical variogram type `V` to empirical variogram `γ`
 using algorithm `algo`. Default algorithm is `WeightedLeastSquares`.


### PR DESCRIPTION
@juliohm 

dumpted repo strings exposed a solitary typo

```
$ ed -s Variography.jl/src/fitting.jl <<<'29,38p'
"""
    fit(V, γ, [algo])
    fit(V, γ, [weigthfun])

Fit theoretical variogram type `V` to empirical variogram `γ`
using algorithm `algo`. Default algorithm is `WeightedLeastSquares`.

Alternatively pass the weighting function `weightfun` directly
to the fitting procedure.
"""
$ 
```