### PR TITLE
remove lambdas from skip, exit and neighbors

### DIFF
--- a/src/algorithms/ballsearch.jl
+++ b/src/algorithms/ballsearch.jl
@@ -14,12 +14,12 @@ struct BallSearchAccum{T,D} <: VariogramAccumAlgo
   distance::D
 end
 
-function neighfun(algo::BallSearchAccum, pset)
+function _neighbors(algo::BallSearchAccum, pset, j)
   ball = MetricBall(algo.maxlag, algo.distance)
   searcher = BallSearch(pset, ball)
-  j -> @inbounds(search(pset[j], searcher))
+  @inbounds(search(pset[j], searcher))
 end
 
-skipfun(::BallSearchAccum) = (i, j) -> i ≤ j
+_skip(::BallSearchAccum, i, j) = i ≤ j
 
-exitfun(::BallSearchAccum) = h -> false
+_exit(::BallSearchAccum, h) = false

--- a/src/algorithms/fullsearch.jl
+++ b/src/algorithms/fullsearch.jl
@@ -14,8 +14,8 @@ struct FullSearchAccum{T,D} <: VariogramAccumAlgo
   distance::D
 end
 
-neighfun(::FullSearchAccum, pset) = j -> (j + 1):nelements(pset)
+_neighbors(::FullSearchAccum, pset, j) = (j + 1):nelements(pset)
 
-skipfun(::FullSearchAccum) = (i, j) -> false
+_skip(::FullSearchAccum, i, j) = false
 
-exitfun(algo::FullSearchAccum) = h -> h > algo.maxlag
+_exit(algo::FullSearchAccum, h) = h > algo.maxlag

--- a/src/empirical.jl
+++ b/src/empirical.jl
@@ -47,15 +47,6 @@ function accumulate(data, var₁, var₂, estim::VariogramEstimator, algo::Vario
   z₁ = Tables.getcolumn(cols, var₁)
   z₂ = Tables.getcolumn(cols, var₂)
 
-  # neighbors function
-  neighbors = neighfun(algo, 𝒫)
-
-  # skip condition
-  skip = skipfun(algo)
-
-  # early exit condition
-  exit = exitfun(algo)
-
   # accumulation type
   V = result_type(estim, z₁, z₂)
 
@@ -69,9 +60,9 @@ function accumulate(data, var₁, var₂, estim::VariogramEstimator, algo::Vario
     pⱼ = 𝒫[j]
     z₁ⱼ = z₁[j]
     z₂ⱼ = z₂[j]
-    for i in neighbors(j)
+    for i in _neighbors(algo, 𝒫, j)
       # skip to avoid double counting
-      skip(i, j) && continue
+      _skip(algo, i, j) && continue
 
       pᵢ = 𝒫[i]
       z₁ᵢ = z₁[i]
@@ -81,7 +72,7 @@ function accumulate(data, var₁, var₂, estim::VariogramEstimator, algo::Vario
       h = evaluate(distance, coordinates(pᵢ), coordinates(pⱼ))
 
       # early exit if out of range
-      exit(h) && continue
+      _exit(algo, h) && continue
 
       # evaluate (cross-)variance
       v = formula(estim, z₁ᵢ, z₁ⱼ, z₂ᵢ, z₂ⱼ)


### PR DESCRIPTION

Here I tried to remove the lambdas from `skip`, `exit`, and `neighbors` functions. 

I prefer this style, but that is mostly about taste here. Also I renamed `skipfun` etc. to `_skip` for each method, because it seemed cleaner when these functions are called. Also this change is only about taste.

I hope it helps, but feel free to ignore.